### PR TITLE
Fixed header and footer overflowing body contents

### DIFF
--- a/recipes/static/recipes/css/main.css
+++ b/recipes/static/recipes/css/main.css
@@ -4,18 +4,16 @@ html {
   min-height: 100%
 }
 body {
-  height: 100%;
   min-height: 100%;
-  padding-top: 62px;
-  padding-bottom: 200px
+  height: 100%
 }
 .footer {
   background-color: #282c30;
-  width: 100%;
   position: absolute;
+  min-height: 200px;
+  width: 100%;
   bottom: 0;
-  left: 0;
-  height: 200px
+  left: 0
 }
 .footer-copyright ul li { font-size: 12px; list-style: none }
 
@@ -212,7 +210,6 @@ img.account-img {
   /* Footer */
   .footer-copyright ul li { font-size: 10px }
   .footer {
-    height: 350px;
     flex-direction: column;
     flex-flow: wrap;
     align-items: flex-start;
@@ -229,7 +226,6 @@ img.account-img {
     margin-bottom: 2px !important;
     color: #c9c9c9
   }
-  body { padding-bottom: 350px }
 
 
 

--- a/recipes/static/recipes/js/main.js
+++ b/recipes/static/recipes/js/main.js
@@ -29,6 +29,18 @@ function getCookie(cname)
 
 
 
+/* Prevent Header and Footer from interfering the Body */
+function adjustHeaderAndFooter()
+{
+	$('body').css({
+		'padding-top': $('header > nav').outerHeight()+'px',
+		'padding-bottom': $('footer').outerHeight()+'px'
+	})
+}
+
+
+
+
 /* shows scroll-to-top button if we scroll 
 beyond the height of the initial window. */
 const scrollFunc = () => {
@@ -45,17 +57,30 @@ window.addEventListener('scroll', scrollFunc);
 
 
 
+
 $(document).ready(function()
 {
+	adjustHeaderAndFooter();
+	$(window).resize((function() {
+		var timeout = null;
+		return function() {
+			if (timeout) clearTimeout(timeout);
+			timeout = setTimeout(adjustHeaderAndFooter(), 250)
+		}
+	})());
+
+
 	$('#scroll-to-top-button').hide();
-	$('a.disabled').click(function() {
-    	if ($(this).hasClass('disabled')) {
-    		return false
-    	}
-    	else {
-    		$(this).trigger('click')
-    	}
-    });
+	$('a.disabled').click( function()
+	{
+		if ($(this).hasClass('disabled')) {
+			return false
+		}
+		else {
+			$(this).trigger('click')
+		}
+	});
+
 
 	/* Cookies toggle animation */
 	if (!getCookie('hide_cookies_popup')) { 


### PR DESCRIPTION
The previous update has not fully fixed the issue due to the assigned fixed height of the footer and header. This issue has been resolved using javascript+jQuery.

Functions on_load and on_resize will call a custom function that will update the body top and bottom padding based on the current size of the footer and header.

There was an issue with the DOM window resize function, so I suggest avoiding it if it comes to frequent calls. See this for more detail of the issue that I have encountered -> https://stackoverflow.com/questions/3230359/window-resize-is-being-sluggish