### PR TITLE
Fixed .select-country element on production

### DIFF
--- a/recipes/templates/recipes/extensions/search_bar.html
+++ b/recipes/templates/recipes/extensions/search_bar.html
@@ -59,258 +59,258 @@
         <div id="select-country" class="input-group mt-1" style="height: 30px">
           <label class="input-group-text h-100 rounded-0" style="width: 40px"></label>
           <select name="nationality" class="form-select select-country h-100 padding-0" style="font-size: 12px" aria-label="Select country filter">
-            <option value="AF">Afghanistan</option>
-            <option value="AX">Aland Islands</option>
-            <option value="AL">Albania</option>
-            <option value="DZ">Algeria</option>
-            <option value="AS">American Samoa</option>
-            <option value="AD">Andorra</option>
-            <option value="AO">Angola</option>
-            <option value="AI">Anguilla</option>
-            <option value="AQ">Antarctica</option>
-            <option value="AG">Antigua and Barbuda</option>
-            <option value="AR">Argentina</option>
-            <option value="AM">Armenia</option>
-            <option value="AW">Aruba</option>
-            <option value="AU">Australia</option>
-            <option value="AT">Austria</option>
-            <option value="AZ">Azerbaijan</option>
-            <option value="BS">Bahamas</option>
-            <option value="BH">Bahrain</option>
-            <option value="BD">Bangladesh</option>
-            <option value="BB">Barbados</option>
-            <option value="BY">Belarus</option>
-            <option value="BE">Belgium</option>
-            <option value="BZ">Belize</option>
-            <option value="BJ">Benin</option>
-            <option value="BM">Bermuda</option>
-            <option value="BT">Bhutan</option>
-            <option value="BO">Bolivia</option>
-            <option value="BQ">Bonaire, Sint Eustatius and Saba</option>
-            <option value="BA">Bosnia and Herzegovina</option>
-            <option value="BW">Botswana</option>
-            <option value="BV">Bouvet Island</option>
-            <option value="BR">Brazil</option>
-            <option value="IO">British Indian Ocean Territory</option>
-            <option value="BN">Brunei Darussalam</option>
-            <option value="BG">Bulgaria</option>
-            <option value="BF">Burkina Faso</option>
-            <option value="BI">Burundi</option>
-            <option value="KH">Cambodia</option>
-            <option value="CM">Cameroon</option>
-            <option value="CA">Canada</option>
-            <option value="CV">Cape Verde</option>
-            <option value="KY">Cayman Islands</option>
-            <option value="CF">Central African Republic</option>
-            <option value="TD">Chad</option>
-            <option value="CL">Chile</option>
-            <option value="CN">China</option>
-            <option value="CX">Christmas Island</option>
-            <option value="CC">Cocos (Keeling) Islands</option>
-            <option value="CO">Colombia</option>
-            <option value="KM">Comoros</option>
-            <option value="CG">Congo</option>
-            <option value="CD">Congo, Democratic Republic of the Congo</option>
-            <option value="CK">Cook Islands</option>
-            <option value="CR">Costa Rica</option>
-            <option value="CI">Cote D'Ivoire</option>
-            <option value="HR">Croatia</option>
-            <option value="CU">Cuba</option>
-            <option value="CW">Curacao</option>
-            <option value="CY">Cyprus</option>
-            <option value="CZ">Czech Republic</option>
-            <option value="DK">Denmark</option>
-            <option value="DJ">Djibouti</option>
-            <option value="DM">Dominica</option>
-            <option value="DO">Dominican Republic</option>
-            <option value="EC">Ecuador</option>
-            <option value="EG">Egypt</option>
-            <option value="SV">El Salvador</option>
-            <option value="GQ">Equatorial Guinea</option>
-            <option value="ER">Eritrea</option>
-            <option value="EE">Estonia</option>
-            <option value="ET">Ethiopia</option>
-            <option value="FK">Falkland Islands (Malvinas)</option>
-            <option value="FO">Faroe Islands</option>
-            <option value="FJ">Fiji</option>
-            <option value="FI">Finland</option>
-            <option value="FR">France</option>
-            <option value="GF">French Guiana</option>
-            <option value="PF">French Polynesia</option>
-            <option value="TF">French Southern Territories</option>
-            <option value="GA">Gabon</option>
-            <option value="GM">Gambia</option>
-            <option value="GE">Georgia</option>
-            <option value="DE">Germany</option>
-            <option value="GH">Ghana</option>
-            <option value="GI">Gibraltar</option>
-            <option value="GR">Greece</option>
-            <option value="GL">Greenland</option>
-            <option value="GD">Grenada</option>
-            <option value="GP">Guadeloupe</option>
-            <option value="GU">Guam</option>
-            <option value="GT">Guatemala</option>
-            <option value="GG">Guernsey</option>
-            <option value="GN">Guinea</option>
-            <option value="GW">Guinea-Bissau</option>
-            <option value="GY">Guyana</option>
-            <option value="HT">Haiti</option>
-            <option value="HM">Heard Island and Mcdonald Islands</option>
-            <option value="VA">Holy See (Vatican City State)</option>
-            <option value="HN">Honduras</option>
-            <option value="HK">Hong Kong</option>
-            <option value="HU">Hungary</option>
-            <option value="IS">Iceland</option>
-            <option value="IN">India</option>
-            <option value="ID">Indonesia</option>
-            <option value="IR">Iran, Islamic Republic of</option>
-            <option value="IQ">Iraq</option>
-            <option value="IE">Ireland</option>
-            <option value="IM">Isle of Man</option>
-            <option value="IL">Israel</option>
-            <option value="IT">Italy</option>
-            <option value="JM">Jamaica</option>
-            <option value="JP">Japan</option>
-            <option value="JE">Jersey</option>
-            <option value="JO">Jordan</option>
-            <option value="KZ">Kazakhstan</option>
-            <option value="KE">Kenya</option>
-            <option value="KI">Kiribati</option>
-            <option value="KP">Korea, Democratic People's Republic of</option>
-            <option value="KR">Korea, Republic of</option>
-            <option value="XK">Kosovo</option>
-            <option value="KW">Kuwait</option>
-            <option value="KG">Kyrgyzstan</option>
-            <option value="LA">Lao People's Democratic Republic</option>
-            <option value="LV">Latvia</option>
-            <option value="LB">Lebanon</option>
-            <option value="LS">Lesotho</option>
-            <option value="LR">Liberia</option>
-            <option value="LY">Libyan Arab Jamahiriya</option>
-            <option value="LI">Liechtenstein</option>
-            <option value="LT">Lithuania</option>
-            <option value="LU">Luxembourg</option>
-            <option value="MO">Macao</option>
-            <option value="MK">Macedonia, the Former Yugoslav Republic of</option>
-            <option value="MG">Madagascar</option>
-            <option value="MW">Malawi</option>
-            <option value="MY">Malaysia</option>
-            <option value="MV">Maldives</option>
-            <option value="ML">Mali</option>
-            <option value="MT">Malta</option>
-            <option value="MH">Marshall Islands</option>
-            <option value="MQ">Martinique</option>
-            <option value="MR">Mauritania</option>
-            <option value="MU">Mauritius</option>
-            <option value="YT">Mayotte</option>
-            <option value="MX">Mexico</option>
-            <option value="FM">Micronesia, Federated States of</option>
-            <option value="MD">Moldova, Republic of</option>
-            <option value="MC">Monaco</option>
-            <option value="MN">Mongolia</option>
-            <option value="ME">Montenegro</option>
-            <option value="MS">Montserrat</option>
-            <option value="MA">Morocco</option>
-            <option value="MZ">Mozambique</option>
-            <option value="MM">Myanmar</option>
-            <option value="NA">Namibia</option>
-            <option value="NR">Nauru</option>
-            <option value="NP">Nepal</option>
-            <option value="NL">Netherlands</option>
-            <option value="AN">Netherlands Antilles</option>
-            <option value="NC">New Caledonia</option>
-            <option value="NZ">New Zealand</option>
-            <option value="NI">Nicaragua</option>
-            <option value="NE">Niger</option>
-            <option value="NG">Nigeria</option>
-            <option value="NU">Niue</option>
-            <option value="NF">Norfolk Island</option>
-            <option value="MP">Northern Mariana Islands</option>
-            <option value="NO">Norway</option>
-            <option value="OM">Oman</option>
-            <option value="PK">Pakistan</option>
-            <option value="PW">Palau</option>
-            <option value="PS">Palestinian Territory, Occupied</option>
-            <option value="PA">Panama</option>
-            <option value="PG">Papua New Guinea</option>
-            <option value="PY">Paraguay</option>
-            <option value="PE">Peru</option>
-            <option value="PH">Philippines</option>
-            <option value="PN">Pitcairn</option>
-            <option value="PL">Poland</option>
-            <option value="PT">Portugal</option>
-            <option value="PR">Puerto Rico</option>
-            <option value="QA">Qatar</option>
-            <option value="RE">Reunion</option>
-            <option value="RO">Romania</option>
-            <option value="RU">Russian Federation</option>
-            <option value="RW">Rwanda</option>
-            <option value="BL">Saint Barthelemy</option>
-            <option value="SH">Saint Helena</option>
-            <option value="KN">Saint Kitts and Nevis</option>
-            <option value="LC">Saint Lucia</option>
-            <option value="MF">Saint Martin</option>
-            <option value="PM">Saint Pierre and Miquelon</option>
-            <option value="VC">Saint Vincent and the Grenadines</option>
-            <option value="WS">Samoa</option>
-            <option value="SM">San Marino</option>
-            <option value="ST">Sao Tome and Principe</option>
-            <option value="SA">Saudi Arabia</option>
-            <option value="SN">Senegal</option>
-            <option value="RS">Serbia</option>
-            <option value="CS">Serbia and Montenegro</option>
-            <option value="SC">Seychelles</option>
-            <option value="SL">Sierra Leone</option>
-            <option value="SG">Singapore</option>
-            <option value="SX">Sint Maarten</option>
-            <option value="SK">Slovakia</option>
-            <option value="SI">Slovenia</option>
-            <option value="SB">Solomon Islands</option>
-            <option value="SO">Somalia</option>
-            <option value="ZA">South Africa</option>
-            <option value="GS">South Georgia and the South Sandwich Islands</option>
-            <option value="SS">South Sudan</option>
-            <option value="ES">Spain</option>
-            <option value="LK">Sri Lanka</option>
-            <option value="SD">Sudan</option>
-            <option value="SR">Suriname</option>
-            <option value="SJ">Svalbard and Jan Mayen</option>
-            <option value="SZ">Swaziland</option>
-            <option value="SE">Sweden</option>
-            <option value="CH">Switzerland</option>
-            <option value="SY">Syrian Arab Republic</option>
-            <option value="TW">Taiwan, Province of China</option>
-            <option value="TJ">Tajikistan</option>
-            <option value="TZ">Tanzania, United Republic of</option>
-            <option value="TH">Thailand</option>
-            <option value="TL">Timor-Leste</option>
-            <option value="TG">Togo</option>
-            <option value="TK">Tokelau</option>
-            <option value="TO">Tonga</option>
-            <option value="TT">Trinidad and Tobago</option>
-            <option value="TN">Tunisia</option>
-            <option value="TR">Turkey</option>
-            <option value="TM">Turkmenistan</option>
-            <option value="TC">Turks and Caicos Islands</option>
-            <option value="TV">Tuvalu</option>
-            <option value="UG">Uganda</option>
-            <option value="UA">Ukraine</option>
-            <option value="AE">United Arab Emirates</option>
-            <option value="GB">United Kingdom</option>
-            <option value="US">United States</option>
-            <option value="UM">United States Minor Outlying Islands</option>
-            <option value="UY">Uruguay</option>
-            <option value="UZ">Uzbekistan</option>
-            <option value="VU">Vanuatu</option>
-            <option value="VE">Venezuela</option>
-            <option value="VN">Viet Nam</option>
-            <option value="VG">Virgin Islands, British</option>
-            <option value="VI">Virgin Islands, U.s.</option>
-            <option value="WF">Wallis and Futuna</option>
-            <option value="EH">Western Sahara</option>
-            <option value="YE">Yemen</option>
-            <option value="ZM">Zambia</option>
-            <option value="ZW">Zimbabwe</option>
+            <option value="AF" data-flag-src="{% static 'recipes/img/icons/flags/AF.svg' %}">Afghanistan</option>
+            <option value="AX" data-flag-src="{% static 'recipes/img/icons/flags/AX.svg' %}">Aland Islands</option>
+            <option value="AL" data-flag-src="{% static 'recipes/img/icons/flags/AL.svg' %}">Albania</option>
+            <option value="DZ" data-flag-src="{% static 'recipes/img/icons/flags/DZ.svg' %}">Algeria</option>
+            <option value="AS" data-flag-src="{% static 'recipes/img/icons/flags/AS.svg' %}">American Samoa</option>
+            <option value="AD" data-flag-src="{% static 'recipes/img/icons/flags/AD.svg' %}">Andorra</option>
+            <option value="AO" data-flag-src="{% static 'recipes/img/icons/flags/AO.svg' %}">Angola</option>
+            <option value="AI" data-flag-src="{% static 'recipes/img/icons/flags/AI.svg' %}">Anguilla</option>
+            <option value="AQ" data-flag-src="{% static 'recipes/img/icons/flags/AQ.svg' %}">Antarctica</option>
+            <option value="AG" data-flag-src="{% static 'recipes/img/icons/flags/AG.svg' %}">Antigua and Barbuda</option>
+            <option value="AR" data-flag-src="{% static 'recipes/img/icons/flags/AR.svg' %}">Argentina</option>
+            <option value="AM" data-flag-src="{% static 'recipes/img/icons/flags/AM.svg' %}">Armenia</option>
+            <option value="AW" data-flag-src="{% static 'recipes/img/icons/flags/AW.svg' %}">Aruba</option>
+            <option value="AU" data-flag-src="{% static 'recipes/img/icons/flags/AU.svg' %}">Australia</option>
+            <option value="AT" data-flag-src="{% static 'recipes/img/icons/flags/AT.svg' %}">Austria</option>
+            <option value="AZ" data-flag-src="{% static 'recipes/img/icons/flags/AZ.svg' %}">Azerbaijan</option>
+            <option value="BS" data-flag-src="{% static 'recipes/img/icons/flags/BS.svg' %}">Bahamas</option>
+            <option value="BH" data-flag-src="{% static 'recipes/img/icons/flags/BH.svg' %}">Bahrain</option>
+            <option value="BD" data-flag-src="{% static 'recipes/img/icons/flags/BD.svg' %}">Bangladesh</option>
+            <option value="BB" data-flag-src="{% static 'recipes/img/icons/flags/BB.svg' %}">Barbados</option>
+            <option value="BY" data-flag-src="{% static 'recipes/img/icons/flags/BY.svg' %}">Belarus</option>
+            <option value="BE" data-flag-src="{% static 'recipes/img/icons/flags/BE.svg' %}">Belgium</option>
+            <option value="BZ" data-flag-src="{% static 'recipes/img/icons/flags/BZ.svg' %}">Belize</option>
+            <option value="BJ" data-flag-src="{% static 'recipes/img/icons/flags/BJ.svg' %}">Benin</option>
+            <option value="BM" data-flag-src="{% static 'recipes/img/icons/flags/BM.svg' %}">Bermuda</option>
+            <option value="BT" data-flag-src="{% static 'recipes/img/icons/flags/BT.svg' %}">Bhutan</option>
+            <option value="BO" data-flag-src="{% static 'recipes/img/icons/flags/BO.svg' %}">Bolivia</option>
+            <option value="BQ" data-flag-src="{% static 'recipes/img/icons/flags/BQ.svg' %}">Bonaire, Sint Eustatius and Saba</option>
+            <option value="BA" data-flag-src="{% static 'recipes/img/icons/flags/BA.svg' %}">Bosnia and Herzegovina</option>
+            <option value="BW" data-flag-src="{% static 'recipes/img/icons/flags/BW.svg' %}">Botswana</option>
+            <option value="BV" data-flag-src="{% static 'recipes/img/icons/flags/BV.svg' %}">Bouvet Island</option>
+            <option value="BR" data-flag-src="{% static 'recipes/img/icons/flags/BR.svg' %}">Brazil</option>
+            <option value="IO" data-flag-src="{% static 'recipes/img/icons/flags/IO.svg' %}">British Indian Ocean Territory</option>
+            <option value="BN" data-flag-src="{% static 'recipes/img/icons/flags/BN.svg' %}">Brunei Darussalam</option>
+            <option value="BG" data-flag-src="{% static 'recipes/img/icons/flags/BG.svg' %}">Bulgaria</option>
+            <option value="BF" data-flag-src="{% static 'recipes/img/icons/flags/BF.svg' %}">Burkina Faso</option>
+            <option value="BI" data-flag-src="{% static 'recipes/img/icons/flags/BI.svg' %}">Burundi</option>
+            <option value="KH" data-flag-src="{% static 'recipes/img/icons/flags/KH.svg' %}">Cambodia</option>
+            <option value="CM" data-flag-src="{% static 'recipes/img/icons/flags/CM.svg' %}">Cameroon</option>
+            <option value="CA" data-flag-src="{% static 'recipes/img/icons/flags/CA.svg' %}">Canada</option>
+            <option value="CV" data-flag-src="{% static 'recipes/img/icons/flags/CV.svg' %}">Cape Verde</option>
+            <option value="KY" data-flag-src="{% static 'recipes/img/icons/flags/KY.svg' %}">Cayman Islands</option>
+            <option value="CF" data-flag-src="{% static 'recipes/img/icons/flags/CF.svg' %}">Central African Republic</option>
+            <option value="TD" data-flag-src="{% static 'recipes/img/icons/flags/TD.svg' %}">Chad</option>
+            <option value="CL" data-flag-src="{% static 'recipes/img/icons/flags/CL.svg' %}">Chile</option>
+            <option value="CN" data-flag-src="{% static 'recipes/img/icons/flags/CN.svg' %}">China</option>
+            <option value="CX" data-flag-src="{% static 'recipes/img/icons/flags/CX.svg' %}">Christmas Island</option>
+            <option value="CC" data-flag-src="{% static 'recipes/img/icons/flags/CC.svg' %}">Cocos (Keeling) Islands</option>
+            <option value="CO" data-flag-src="{% static 'recipes/img/icons/flags/CO.svg' %}">Colombia</option>
+            <option value="KM" data-flag-src="{% static 'recipes/img/icons/flags/KM.svg' %}">Comoros</option>
+            <option value="CG" data-flag-src="{% static 'recipes/img/icons/flags/CG.svg' %}">Congo</option>
+            <option value="CD" data-flag-src="{% static 'recipes/img/icons/flags/CD.svg' %}">Congo, Democratic Republic of the Congo</option>
+            <option value="CK" data-flag-src="{% static 'recipes/img/icons/flags/CK.svg' %}">Cook Islands</option>
+            <option value="CR" data-flag-src="{% static 'recipes/img/icons/flags/CR.svg' %}">Costa Rica</option>
+            <option value="CI" data-flag-src="{% static 'recipes/img/icons/flags/CI.svg' %}">Cote D'Ivoire</option>
+            <option value="HR" data-flag-src="{% static 'recipes/img/icons/flags/HR.svg' %}">Croatia</option>
+            <option value="CU" data-flag-src="{% static 'recipes/img/icons/flags/CU.svg' %}">Cuba</option>
+            <option value="CW" data-flag-src="{% static 'recipes/img/icons/flags/CW.svg' %}">Curacao</option>
+            <option value="CY" data-flag-src="{% static 'recipes/img/icons/flags/CY.svg' %}">Cyprus</option>
+            <option value="CZ" data-flag-src="{% static 'recipes/img/icons/flags/CZ.svg' %}">Czech Republic</option>
+            <option value="DK" data-flag-src="{% static 'recipes/img/icons/flags/DK.svg' %}">Denmark</option>
+            <option value="DJ" data-flag-src="{% static 'recipes/img/icons/flags/DJ.svg' %}">Djibouti</option>
+            <option value="DM" data-flag-src="{% static 'recipes/img/icons/flags/DM.svg' %}">Dominica</option>
+            <option value="DO" data-flag-src="{% static 'recipes/img/icons/flags/DO.svg' %}">Dominican Republic</option>
+            <option value="EC" data-flag-src="{% static 'recipes/img/icons/flags/EC.svg' %}">Ecuador</option>
+            <option value="EG" data-flag-src="{% static 'recipes/img/icons/flags/EG.svg' %}">Egypt</option>
+            <option value="SV" data-flag-src="{% static 'recipes/img/icons/flags/SV.svg' %}">El Salvador</option>
+            <option value="GQ" data-flag-src="{% static 'recipes/img/icons/flags/GQ.svg' %}">Equatorial Guinea</option>
+            <option value="ER" data-flag-src="{% static 'recipes/img/icons/flags/ER.svg' %}">Eritrea</option>
+            <option value="EE" data-flag-src="{% static 'recipes/img/icons/flags/EE.svg' %}">Estonia</option>
+            <option value="ET" data-flag-src="{% static 'recipes/img/icons/flags/ET.svg' %}">Ethiopia</option>
+            <option value="FK" data-flag-src="{% static 'recipes/img/icons/flags/FK.svg' %}">Falkland Islands (Malvinas)</option>
+            <option value="FO" data-flag-src="{% static 'recipes/img/icons/flags/FO.svg' %}">Faroe Islands</option>
+            <option value="FJ" data-flag-src="{% static 'recipes/img/icons/flags/FJ.svg' %}">Fiji</option>
+            <option value="FI" data-flag-src="{% static 'recipes/img/icons/flags/FI.svg' %}">Finland</option>
+            <option value="FR" data-flag-src="{% static 'recipes/img/icons/flags/FR.svg' %}">France</option>
+            <option value="GF" data-flag-src="{% static 'recipes/img/icons/flags/GF.svg' %}">French Guiana</option>
+            <option value="PF" data-flag-src="{% static 'recipes/img/icons/flags/PF.svg' %}">French Polynesia</option>
+            <option value="TF" data-flag-src="{% static 'recipes/img/icons/flags/TF.svg' %}">French Southern Territories</option>
+            <option value="GA" data-flag-src="{% static 'recipes/img/icons/flags/GA.svg' %}">Gabon</option>
+            <option value="GM" data-flag-src="{% static 'recipes/img/icons/flags/GM.svg' %}">Gambia</option>
+            <option value="GE" data-flag-src="{% static 'recipes/img/icons/flags/GE.svg' %}">Georgia</option>
+            <option value="DE" data-flag-src="{% static 'recipes/img/icons/flags/DE.svg' %}">Germany</option>
+            <option value="GH" data-flag-src="{% static 'recipes/img/icons/flags/GH.svg' %}">Ghana</option>
+            <option value="GI" data-flag-src="{% static 'recipes/img/icons/flags/GI.svg' %}">Gibraltar</option>
+            <option value="GR" data-flag-src="{% static 'recipes/img/icons/flags/GR.svg' %}">Greece</option>
+            <option value="GL" data-flag-src="{% static 'recipes/img/icons/flags/GL.svg' %}">Greenland</option>
+            <option value="GD" data-flag-src="{% static 'recipes/img/icons/flags/GD.svg' %}">Grenada</option>
+            <option value="GP" data-flag-src="{% static 'recipes/img/icons/flags/GP.svg' %}">Guadeloupe</option>
+            <option value="GU" data-flag-src="{% static 'recipes/img/icons/flags/GU.svg' %}">Guam</option>
+            <option value="GT" data-flag-src="{% static 'recipes/img/icons/flags/GT.svg' %}">Guatemala</option>
+            <option value="GG" data-flag-src="{% static 'recipes/img/icons/flags/GG.svg' %}">Guernsey</option>
+            <option value="GN" data-flag-src="{% static 'recipes/img/icons/flags/GN.svg' %}">Guinea</option>
+            <option value="GW" data-flag-src="{% static 'recipes/img/icons/flags/GW.svg' %}">Guinea-Bissau</option>
+            <option value="GY" data-flag-src="{% static 'recipes/img/icons/flags/GY.svg' %}">Guyana</option>
+            <option value="HT" data-flag-src="{% static 'recipes/img/icons/flags/HT.svg' %}">Haiti</option>
+            <option value="HM" data-flag-src="{% static 'recipes/img/icons/flags/HM.svg' %}">Heard Island and Mcdonald Islands</option>
+            <option value="VA" data-flag-src="{% static 'recipes/img/icons/flags/VA.svg' %}">Holy See (Vatican City State)</option>
+            <option value="HN" data-flag-src="{% static 'recipes/img/icons/flags/HN.svg' %}">Honduras</option>
+            <option value="HK" data-flag-src="{% static 'recipes/img/icons/flags/HK.svg' %}">Hong Kong</option>
+            <option value="HU" data-flag-src="{% static 'recipes/img/icons/flags/HU.svg' %}">Hungary</option>
+            <option value="IS" data-flag-src="{% static 'recipes/img/icons/flags/IS.svg' %}">Iceland</option>
+            <option value="IN" data-flag-src="{% static 'recipes/img/icons/flags/IN.svg' %}">India</option>
+            <option value="ID" data-flag-src="{% static 'recipes/img/icons/flags/ID.svg' %}">Indonesia</option>
+            <option value="IR" data-flag-src="{% static 'recipes/img/icons/flags/IR.svg' %}">Iran, Islamic Republic of</option>
+            <option value="IQ" data-flag-src="{% static 'recipes/img/icons/flags/IQ.svg' %}">Iraq</option>
+            <option value="IE" data-flag-src="{% static 'recipes/img/icons/flags/IE.svg' %}">Ireland</option>
+            <option value="IM" data-flag-src="{% static 'recipes/img/icons/flags/IM.svg' %}">Isle of Man</option>
+            <option value="IL" data-flag-src="{% static 'recipes/img/icons/flags/IL.svg' %}">Israel</option>
+            <option value="IT" data-flag-src="{% static 'recipes/img/icons/flags/IT.svg' %}">Italy</option>
+            <option value="JM" data-flag-src="{% static 'recipes/img/icons/flags/JM.svg' %}">Jamaica</option>
+            <option value="JP" data-flag-src="{% static 'recipes/img/icons/flags/JP.svg' %}">Japan</option>
+            <option value="JE" data-flag-src="{% static 'recipes/img/icons/flags/JE.svg' %}">Jersey</option>
+            <option value="JO" data-flag-src="{% static 'recipes/img/icons/flags/JO.svg' %}">Jordan</option>
+            <option value="KZ" data-flag-src="{% static 'recipes/img/icons/flags/KZ.svg' %}">Kazakhstan</option>
+            <option value="KE" data-flag-src="{% static 'recipes/img/icons/flags/KE.svg' %}">Kenya</option>
+            <option value="KI" data-flag-src="{% static 'recipes/img/icons/flags/KI.svg' %}">Kiribati</option>
+            <option value="KP" data-flag-src="{% static 'recipes/img/icons/flags/KP.svg' %}">Korea, Democratic People's Republic of</option>
+            <option value="KR" data-flag-src="{% static 'recipes/img/icons/flags/KR.svg' %}">Korea, Republic of</option>
+            <option value="XK" data-flag-src="{% static 'recipes/img/icons/flags/XK.svg' %}">Kosovo</option>
+            <option value="KW" data-flag-src="{% static 'recipes/img/icons/flags/KW.svg' %}">Kuwait</option>
+            <option value="KG" data-flag-src="{% static 'recipes/img/icons/flags/KG.svg' %}">Kyrgyzstan</option>
+            <option value="LA" data-flag-src="{% static 'recipes/img/icons/flags/LA.svg' %}">Lao People's Democratic Republic</option>
+            <option value="LV" data-flag-src="{% static 'recipes/img/icons/flags/LV.svg' %}">Latvia</option>
+            <option value="LB" data-flag-src="{% static 'recipes/img/icons/flags/LB.svg' %}">Lebanon</option>
+            <option value="LS" data-flag-src="{% static 'recipes/img/icons/flags/LS.svg' %}">Lesotho</option>
+            <option value="LR" data-flag-src="{% static 'recipes/img/icons/flags/LR.svg' %}">Liberia</option>
+            <option value="LY" data-flag-src="{% static 'recipes/img/icons/flags/LY.svg' %}">Libyan Arab Jamahiriya</option>
+            <option value="LI" data-flag-src="{% static 'recipes/img/icons/flags/LI.svg' %}">Liechtenstein</option>
+            <option value="LT" data-flag-src="{% static 'recipes/img/icons/flags/LT.svg' %}">Lithuania</option>
+            <option value="LU" data-flag-src="{% static 'recipes/img/icons/flags/LU.svg' %}">Luxembourg</option>
+            <option value="MO" data-flag-src="{% static 'recipes/img/icons/flags/MO.svg' %}">Macao</option>
+            <option value="MK" data-flag-src="{% static 'recipes/img/icons/flags/MK.svg' %}">Macedonia, the Former Yugoslav Republic of</option>
+            <option value="MG" data-flag-src="{% static 'recipes/img/icons/flags/MG.svg' %}">Madagascar</option>
+            <option value="MW" data-flag-src="{% static 'recipes/img/icons/flags/MW.svg' %}">Malawi</option>
+            <option value="MY" data-flag-src="{% static 'recipes/img/icons/flags/MY.svg' %}">Malaysia</option>
+            <option value="MV" data-flag-src="{% static 'recipes/img/icons/flags/MV.svg' %}">Maldives</option>
+            <option value="ML" data-flag-src="{% static 'recipes/img/icons/flags/ML.svg' %}">Mali</option>
+            <option value="MT" data-flag-src="{% static 'recipes/img/icons/flags/MT.svg' %}">Malta</option>
+            <option value="MH" data-flag-src="{% static 'recipes/img/icons/flags/MH.svg' %}">Marshall Islands</option>
+            <option value="MQ" data-flag-src="{% static 'recipes/img/icons/flags/MQ.svg' %}">Martinique</option>
+            <option value="MR" data-flag-src="{% static 'recipes/img/icons/flags/MR.svg' %}">Mauritania</option>
+            <option value="MU" data-flag-src="{% static 'recipes/img/icons/flags/MU.svg' %}">Mauritius</option>
+            <option value="YT" data-flag-src="{% static 'recipes/img/icons/flags/YT.svg' %}">Mayotte</option>
+            <option value="MX" data-flag-src="{% static 'recipes/img/icons/flags/MX.svg' %}">Mexico</option>
+            <option value="FM" data-flag-src="{% static 'recipes/img/icons/flags/FM.svg' %}">Micronesia, Federated States of</option>
+            <option value="MD" data-flag-src="{% static 'recipes/img/icons/flags/MD.svg' %}">Moldova, Republic of</option>
+            <option value="MC" data-flag-src="{% static 'recipes/img/icons/flags/MC.svg' %}">Monaco</option>
+            <option value="MN" data-flag-src="{% static 'recipes/img/icons/flags/MN.svg' %}">Mongolia</option>
+            <option value="ME" data-flag-src="{% static 'recipes/img/icons/flags/ME.svg' %}">Montenegro</option>
+            <option value="MS" data-flag-src="{% static 'recipes/img/icons/flags/MS.svg' %}">Montserrat</option>
+            <option value="MA" data-flag-src="{% static 'recipes/img/icons/flags/MA.svg' %}">Morocco</option>
+            <option value="MZ" data-flag-src="{% static 'recipes/img/icons/flags/MZ.svg' %}">Mozambique</option>
+            <option value="MM" data-flag-src="{% static 'recipes/img/icons/flags/MM.svg' %}">Myanmar</option>
+            <option value="NA" data-flag-src="{% static 'recipes/img/icons/flags/NA.svg' %}">Namibia</option>
+            <option value="NR" data-flag-src="{% static 'recipes/img/icons/flags/NR.svg' %}">Nauru</option>
+            <option value="NP" data-flag-src="{% static 'recipes/img/icons/flags/NP.svg' %}">Nepal</option>
+            <option value="NL" data-flag-src="{% static 'recipes/img/icons/flags/NL.svg' %}">Netherlands</option>
+            <option value="AN" data-flag-src="{% static 'recipes/img/icons/flags/AN.svg' %}">Netherlands Antilles</option>
+            <option value="NC" data-flag-src="{% static 'recipes/img/icons/flags/NC.svg' %}">New Caledonia</option>
+            <option value="NZ" data-flag-src="{% static 'recipes/img/icons/flags/NZ.svg' %}">New Zealand</option>
+            <option value="NI" data-flag-src="{% static 'recipes/img/icons/flags/NI.svg' %}">Nicaragua</option>
+            <option value="NE" data-flag-src="{% static 'recipes/img/icons/flags/NE.svg' %}">Niger</option>
+            <option value="NG" data-flag-src="{% static 'recipes/img/icons/flags/NG.svg' %}">Nigeria</option>
+            <option value="NU" data-flag-src="{% static 'recipes/img/icons/flags/NU.svg' %}">Niue</option>
+            <option value="NF" data-flag-src="{% static 'recipes/img/icons/flags/NF.svg' %}">Norfolk Island</option>
+            <option value="MP" data-flag-src="{% static 'recipes/img/icons/flags/MP.svg' %}">Northern Mariana Islands</option>
+            <option value="NO" data-flag-src="{% static 'recipes/img/icons/flags/NO.svg' %}">Norway</option>
+            <option value="OM" data-flag-src="{% static 'recipes/img/icons/flags/OM.svg' %}">Oman</option>
+            <option value="PK" data-flag-src="{% static 'recipes/img/icons/flags/PK.svg' %}">Pakistan</option>
+            <option value="PW" data-flag-src="{% static 'recipes/img/icons/flags/PW.svg' %}">Palau</option>
+            <option value="PS" data-flag-src="{% static 'recipes/img/icons/flags/PS.svg' %}">Palestinian Territory, Occupied</option>
+            <option value="PA" data-flag-src="{% static 'recipes/img/icons/flags/PA.svg' %}">Panama</option>
+            <option value="PG" data-flag-src="{% static 'recipes/img/icons/flags/PG.svg' %}">Papua New Guinea</option>
+            <option value="PY" data-flag-src="{% static 'recipes/img/icons/flags/PY.svg' %}">Paraguay</option>
+            <option value="PE" data-flag-src="{% static 'recipes/img/icons/flags/PE.svg' %}">Peru</option>
+            <option value="PH" data-flag-src="{% static 'recipes/img/icons/flags/PH.svg' %}">Philippines</option>
+            <option value="PN" data-flag-src="{% static 'recipes/img/icons/flags/PN.svg' %}">Pitcairn</option>
+            <option value="PL" data-flag-src="{% static 'recipes/img/icons/flags/PL.svg' %}">Poland</option>
+            <option value="PT" data-flag-src="{% static 'recipes/img/icons/flags/PT.svg' %}">Portugal</option>
+            <option value="PR" data-flag-src="{% static 'recipes/img/icons/flags/PR.svg' %}">Puerto Rico</option>
+            <option value="QA" data-flag-src="{% static 'recipes/img/icons/flags/QA.svg' %}">Qatar</option>
+            <option value="RE" data-flag-src="{% static 'recipes/img/icons/flags/RE.svg' %}">Reunion</option>
+            <option value="RO" data-flag-src="{% static 'recipes/img/icons/flags/RO.svg' %}">Romania</option>
+            <option value="RU" data-flag-src="{% static 'recipes/img/icons/flags/RU.svg' %}">Russian Federation</option>
+            <option value="RW" data-flag-src="{% static 'recipes/img/icons/flags/RW.svg' %}">Rwanda</option>
+            <option value="BL" data-flag-src="{% static 'recipes/img/icons/flags/BL.svg' %}">Saint Barthelemy</option>
+            <option value="SH" data-flag-src="{% static 'recipes/img/icons/flags/SH.svg' %}">Saint Helena</option>
+            <option value="KN" data-flag-src="{% static 'recipes/img/icons/flags/KN.svg' %}">Saint Kitts and Nevis</option>
+            <option value="LC" data-flag-src="{% static 'recipes/img/icons/flags/LC.svg' %}">Saint Lucia</option>
+            <option value="MF" data-flag-src="{% static 'recipes/img/icons/flags/MF.svg' %}">Saint Martin</option>
+            <option value="PM" data-flag-src="{% static 'recipes/img/icons/flags/PM.svg' %}">Saint Pierre and Miquelon</option>
+            <option value="VC" data-flag-src="{% static 'recipes/img/icons/flags/VC.svg' %}">Saint Vincent and the Grenadines</option>
+            <option value="WS" data-flag-src="{% static 'recipes/img/icons/flags/WS.svg' %}">Samoa</option>
+            <option value="SM" data-flag-src="{% static 'recipes/img/icons/flags/SM.svg' %}">San Marino</option>
+            <option value="ST" data-flag-src="{% static 'recipes/img/icons/flags/ST.svg' %}">Sao Tome and Principe</option>
+            <option value="SA" data-flag-src="{% static 'recipes/img/icons/flags/SA.svg' %}">Saudi Arabia</option>
+            <option value="SN" data-flag-src="{% static 'recipes/img/icons/flags/SN.svg' %}">Senegal</option>
+            <option value="RS" data-flag-src="{% static 'recipes/img/icons/flags/RS.svg' %}">Serbia</option>
+            <option value="CS" data-flag-src="{% static 'recipes/img/icons/flags/CS.svg' %}">Serbia and Montenegro</option>
+            <option value="SC" data-flag-src="{% static 'recipes/img/icons/flags/SC.svg' %}">Seychelles</option>
+            <option value="SL" data-flag-src="{% static 'recipes/img/icons/flags/SL.svg' %}">Sierra Leone</option>
+            <option value="SG" data-flag-src="{% static 'recipes/img/icons/flags/SG.svg' %}">Singapore</option>
+            <option value="SX" data-flag-src="{% static 'recipes/img/icons/flags/SX.svg' %}">Sint Maarten</option>
+            <option value="SK" data-flag-src="{% static 'recipes/img/icons/flags/SK.svg' %}">Slovakia</option>
+            <option value="SI" data-flag-src="{% static 'recipes/img/icons/flags/SI.svg' %}">Slovenia</option>
+            <option value="SB" data-flag-src="{% static 'recipes/img/icons/flags/SB.svg' %}">Solomon Islands</option>
+            <option value="SO" data-flag-src="{% static 'recipes/img/icons/flags/SO.svg' %}">Somalia</option>
+            <option value="ZA" data-flag-src="{% static 'recipes/img/icons/flags/ZA.svg' %}">South Africa</option>
+            <option value="GS" data-flag-src="{% static 'recipes/img/icons/flags/GS.svg' %}">South Georgia and the South Sandwich Islands</option>
+            <option value="SS" data-flag-src="{% static 'recipes/img/icons/flags/SS.svg' %}">South Sudan</option>
+            <option value="ES" data-flag-src="{% static 'recipes/img/icons/flags/ES.svg' %}">Spain</option>
+            <option value="LK" data-flag-src="{% static 'recipes/img/icons/flags/LK.svg' %}">Sri Lanka</option>
+            <option value="SD" data-flag-src="{% static 'recipes/img/icons/flags/SD.svg' %}">Sudan</option>
+            <option value="SR" data-flag-src="{% static 'recipes/img/icons/flags/SR.svg' %}">Suriname</option>
+            <option value="SJ" data-flag-src="{% static 'recipes/img/icons/flags/SJ.svg' %}">Svalbard and Jan Mayen</option>
+            <option value="SZ" data-flag-src="{% static 'recipes/img/icons/flags/SZ.svg' %}">Swaziland</option>
+            <option value="SE" data-flag-src="{% static 'recipes/img/icons/flags/SE.svg' %}">Sweden</option>
+            <option value="CH" data-flag-src="{% static 'recipes/img/icons/flags/CH.svg' %}">Switzerland</option>
+            <option value="SY" data-flag-src="{% static 'recipes/img/icons/flags/SY.svg' %}">Syrian Arab Republic</option>
+            <option value="TW" data-flag-src="{% static 'recipes/img/icons/flags/TW.svg' %}">Taiwan, Province of China</option>
+            <option value="TJ" data-flag-src="{% static 'recipes/img/icons/flags/TJ.svg' %}">Tajikistan</option>
+            <option value="TZ" data-flag-src="{% static 'recipes/img/icons/flags/TZ.svg' %}">Tanzania, United Republic of</option>
+            <option value="TH" data-flag-src="{% static 'recipes/img/icons/flags/TH.svg' %}">Thailand</option>
+            <option value="TL" data-flag-src="{% static 'recipes/img/icons/flags/TL.svg' %}">Timor-Leste</option>
+            <option value="TG" data-flag-src="{% static 'recipes/img/icons/flags/TG.svg' %}">Togo</option>
+            <option value="TK" data-flag-src="{% static 'recipes/img/icons/flags/TK.svg' %}">Tokelau</option>
+            <option value="TO" data-flag-src="{% static 'recipes/img/icons/flags/TO.svg' %}">Tonga</option>
+            <option value="TT" data-flag-src="{% static 'recipes/img/icons/flags/TT.svg' %}">Trinidad and Tobago</option>
+            <option value="TN" data-flag-src="{% static 'recipes/img/icons/flags/TN.svg' %}">Tunisia</option>
+            <option value="TR" data-flag-src="{% static 'recipes/img/icons/flags/TR.svg' %}">Turkey</option>
+            <option value="TM" data-flag-src="{% static 'recipes/img/icons/flags/TM.svg' %}">Turkmenistan</option>
+            <option value="TC" data-flag-src="{% static 'recipes/img/icons/flags/TC.svg' %}">Turks and Caicos Islands</option>
+            <option value="TV" data-flag-src="{% static 'recipes/img/icons/flags/TV.svg' %}">Tuvalu</option>
+            <option value="UG" data-flag-src="{% static 'recipes/img/icons/flags/UG.svg' %}">Uganda</option>
+            <option value="UA" data-flag-src="{% static 'recipes/img/icons/flags/UA.svg' %}">Ukraine</option>
+            <option value="AE" data-flag-src="{% static 'recipes/img/icons/flags/AE.svg' %}">United Arab Emirates</option>
+            <option value="GB" data-flag-src="{% static 'recipes/img/icons/flags/GB.svg' %}">United Kingdom</option>
+            <option value="US" data-flag-src="{% static 'recipes/img/icons/flags/US.svg' %}">United States</option>
+            <option value="UM" data-flag-src="{% static 'recipes/img/icons/flags/UM.svg' %}">United States Minor Outlying Islands</option>
+            <option value="UY" data-flag-src="{% static 'recipes/img/icons/flags/UY.svg' %}">Uruguay</option>
+            <option value="UZ" data-flag-src="{% static 'recipes/img/icons/flags/UZ.svg' %}">Uzbekistan</option>
+            <option value="VU" data-flag-src="{% static 'recipes/img/icons/flags/VU.svg' %}">Vanuatu</option>
+            <option value="VE" data-flag-src="{% static 'recipes/img/icons/flags/VE.svg' %}">Venezuela</option>
+            <option value="VN" data-flag-src="{% static 'recipes/img/icons/flags/VN.svg' %}">Viet Nam</option>
+            <option value="VG" data-flag-src="{% static 'recipes/img/icons/flags/VG.svg' %}">Virgin Islands, British</option>
+            <option value="VI" data-flag-src="{% static 'recipes/img/icons/flags/VI.svg' %}">Virgin Islands, U.s.</option>
+            <option value="WF" data-flag-src="{% static 'recipes/img/icons/flags/WF.svg' %}">Wallis and Futuna</option>
+            <option value="EH" data-flag-src="{% static 'recipes/img/icons/flags/EH.svg' %}">Western Sahara</option>
+            <option value="YE" data-flag-src="{% static 'recipes/img/icons/flags/YE.svg' %}">Yemen</option>
+            <option value="ZM" data-flag-src="{% static 'recipes/img/icons/flags/ZM.svg' %}">Zambia</option>
+            <option value="ZW" data-flag-src="{% static 'recipes/img/icons/flags/ZW.svg' %}">Zimbabwe</option>
           </select>
         </div>
       </li>
@@ -327,6 +327,7 @@ let nationality_section  = document.querySelector('section[name="nationality"]')
 let nationality_radios   = nationality_section.querySelectorAll('input[name="nationality_mode"]');
 let nationality_dropdown = nationality_section.querySelector('li[name="nationality-dropdown"]');
 let nationality_select   = nationality_dropdown.querySelector('select[name="nationality"]');
+
 
 [...nationality_radios].map(radio =>
 {
@@ -354,12 +355,12 @@ let nationality_select   = nationality_dropdown.querySelector('select[name="nati
 
 // Set flag icon for #select-country's label
 
-let __flags = `{% static 'recipes/img/icons/flags/' %}`;
-
 const selectCountryUpdateFlag = (selectElement) => {
-  let label = selectElement.parentElement.querySelector('.input-group-text');
+  let label     = selectElement.parentElement.querySelector('.input-group-text');
+  let option    = nationality_select.options[nationality_select.selectedIndex];
+  let __flagSrc = option.dataset.flagSrc;
 
-  label.style.backgroundImage  = `url('${__flags}${selectElement.value}.svg')`;
+  label.style.backgroundImage  = `url('${__flagSrc}')`;
   label.style.backgroundRepeat = 'no-repeat';
   label.style.backgroundSize   = '100% 100%';
 }


### PR DESCRIPTION
I could not access the STATIC files using previous method because the static files in production use STATIC_ROOT and are encrypted.

Django allows to access STATIC_ROOT files using template tags. Hence why I decided to tackle this issue by including the flag images source URL in option's custom data tag "data-flag-src". This way I can access the encrypted flag images.